### PR TITLE
Fix EntityExtension constructor to call default constructor

### DIFF
--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/MethodNewInstanceIntercept.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/MethodNewInstanceIntercept.java
@@ -142,7 +142,7 @@ class MethodNewInstanceIntercept {
     mv.visitLabel(label0);
     mv.visitLineNumber(2, label0);
     mv.visitVarInsn(ALOAD, 0);
-    mv.visitMethodInsn(INVOKESPECIAL, meta.superClassName(), INIT, "()V", false);
+    mv.visitMethodInsn(INVOKESPECIAL, meta.className(), INIT, "()V", false);
     Label label1 = new Label();
     mv.visitLabel(label1);
     mv.visitLineNumber(3, label1);

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -16,7 +16,7 @@
   <description>Runs agent tests using</description>
 
   <properties>
-    <ebean.agent.version>13.10.3-FOC3</ebean.agent.version>
+    <ebean.agent.version>13.10.3-FOC4-SNAPSHOT</ebean.agent.version>
     <ebean.version>13.10.3-FOC2</ebean.version>
   </properties>
 

--- a/test/src/test/java/io/ebean/enhance/common/EntityExtensionTest.java
+++ b/test/src/test/java/io/ebean/enhance/common/EntityExtensionTest.java
@@ -31,7 +31,8 @@ public class EntityExtensionTest {
     BExtension1 ext = new BExtension1();
     assertThat(ext).isInstanceOf(EntityBean.class);
 
-    BExtension1.get(new BEntityBase());
+    BExtension1 extension = BExtension1.get(new BEntityBase());
+    assertThat(extension.getBaz()).isTrue();
 
     Field field = BEntityBaseAbstract.class.getDeclaredField("_ebean_extension_accessors");
     Object ret = field.get(null);

--- a/test/src/test/java/test/model/domain/extend/BExtension1.java
+++ b/test/src/test/java/test/model/domain/extend/BExtension1.java
@@ -13,10 +13,16 @@ public class BExtension1 {
 
   String foo;
 
+  Boolean baz = Boolean.TRUE;
+
   public static BExtension1 get(BEntityBaseAbstract obj) {
     throw new NotEnhancedException();
   }
   public static BExtension1 get(BEntityExtendable obj) {
     throw new NotEnhancedException();
+  }
+
+  public Boolean getBaz() {
+    return baz;
   }
 }


### PR DESCRIPTION
Do not call the super constructor without arguments, but rather the default constructor to preserve the setting of default values within the object